### PR TITLE
CLEREZZA-1022

### DIFF
--- a/jaxrs.rdf.providers/pom.xml
+++ b/jaxrs.rdf.providers/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>org.apache.clerezza</groupId>
             <artifactId>rdf.core</artifactId>
-            <version>1.0.0</version>
+            <version>1.0.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.clerezza</groupId>
@@ -58,11 +58,11 @@
         </dependency>
         <dependency>
             <groupId>javax.ws.rs</groupId>
-            <artifactId>jsr311-api</artifactId>
+            <artifactId>javax.ws.rs-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.scr.annotations</artifactId>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.service.component.annotations</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/jaxrs.rdf.providers/src/main/java/org/apache/clerezza/jaxrs/rdf/providers/GraphNodeWriter.java
+++ b/jaxrs.rdf.providers/src/main/java/org/apache/clerezza/jaxrs/rdf/providers/GraphNodeWriter.java
@@ -27,6 +27,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import javax.ws.rs.Produces;
@@ -44,10 +45,8 @@ import org.apache.clerezza.commons.rdf.Graph;
 import org.apache.clerezza.commons.rdf.IRI;
 import org.apache.clerezza.commons.rdf.impl.utils.simple.SimpleGraph;
 import org.apache.clerezza.rdf.utils.GraphNode;
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.Reference;
-import org.apache.felix.scr.annotations.Service;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * By default this returns a serialization of the context of the GraphNode.
@@ -61,9 +60,7 @@ import org.apache.felix.scr.annotations.Service;
  * @author reto
  */
 
-@Component
-@Service(Object.class)
-@Property(name = "javax.ws.rs", boolValue = true)
+@Component(service=Object.class, property={"javax.ws.rs=true"})
 @Provider
 @Produces({SupportedFormat.N3, SupportedFormat.N_TRIPLE,
     SupportedFormat.RDF_XML, SupportedFormat.TURTLE,
@@ -73,9 +70,19 @@ public class GraphNodeWriter implements MessageBodyWriter<GraphNode> {
     public static final String OBJ_EXP_PARAM = "xPropObj";
     public static final String SUBJ_EXP_PARAM = "xPropSubj";
     
-    @Reference
     private Serializer serializer;
     private UriInfo uriInfo;
+
+    @Reference
+    public synchronized void setSerializer(Serializer serializer) {
+        this.serializer = serializer;
+    }
+
+    public synchronized void unsetSerializer(Serializer serializer) {
+        if (Objects.equals(this.serializer, serializer)) {
+            this.serializer = null;
+        }
+    }
 
     @Override
     public boolean isWriteable(Class<?> type, Type genericType,

--- a/jaxrs.rdf.providers/src/main/java/org/apache/clerezza/jaxrs/rdf/providers/GraphReader.java
+++ b/jaxrs.rdf.providers/src/main/java/org/apache/clerezza/jaxrs/rdf/providers/GraphReader.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
+import java.util.Objects;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
@@ -33,24 +34,30 @@ import org.apache.clerezza.commons.rdf.Graph;
 import org.apache.clerezza.commons.rdf.impl.utils.simple.SimpleGraph;
 import org.apache.clerezza.rdf.core.serializedform.Parser;
 import org.apache.clerezza.rdf.core.serializedform.SupportedFormat;
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.Reference;
-import org.apache.felix.scr.annotations.Service;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 
-@Component
-@Service(Object.class)
-@Property(name = "javax.ws.rs", boolValue = true)
+@Component(service=Object.class, property={"javax.ws.rs=true"})
 @Provider
 @Consumes({SupportedFormat.N3, SupportedFormat.N_TRIPLE,
     SupportedFormat.RDF_XML, SupportedFormat.TURTLE,
     SupportedFormat.X_TURTLE, SupportedFormat.RDF_JSON})
 public class GraphReader implements MessageBodyReader<Graph> {
 
-    @Reference
     private Parser parser;
-    
+
+    @Reference
+    public synchronized void setParser(Parser parser) {
+        this.parser = parser;
+    }
+
+    public synchronized void unsetParser(Parser parser) {
+        if (Objects.equals(this.parser, parser)) {
+            this.parser = null;
+        }
+    }
+
     @Override
     public boolean isReadable(Class<?> type, Type genericType,
             Annotation[] annotations, MediaType mediaType) {

--- a/jaxrs.rdf.providers/src/main/java/org/apache/clerezza/jaxrs/rdf/providers/GraphWriter.java
+++ b/jaxrs.rdf.providers/src/main/java/org/apache/clerezza/jaxrs/rdf/providers/GraphWriter.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
+import java.util.Objects;
 import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
@@ -33,24 +34,30 @@ import javax.ws.rs.ext.Provider;
 import org.apache.clerezza.commons.rdf.Graph;
 import org.apache.clerezza.rdf.core.serializedform.Serializer;
 import org.apache.clerezza.rdf.core.serializedform.SupportedFormat;
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.Reference;
-import org.apache.felix.scr.annotations.Service;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 
-@Component
-@Service(Object.class)
-@Property(name = "javax.ws.rs", boolValue = true)
+@Component(service=Object.class, property={"javax.ws.rs=true"})
 @Provider
 @Produces({SupportedFormat.N3, SupportedFormat.N_TRIPLE,
     SupportedFormat.RDF_XML, SupportedFormat.TURTLE,
     SupportedFormat.X_TURTLE, SupportedFormat.RDF_JSON})
 public class GraphWriter implements MessageBodyWriter<Graph> {
 
-    @Reference
     private Serializer serializer;
-    
+
+    @Reference
+    public synchronized void setSerializer(Serializer serializer) {
+        this.serializer = serializer;
+    }
+
+    public synchronized void unsetSerializer(Serializer serializer) {
+        if (Objects.equals(this.serializer, serializer)) {
+            this.serializer = null;
+        }
+    }
+
     @Override
     public boolean isWriteable(Class<?> type, Type genericType, 
             Annotation[] annotations, MediaType mediaType) {

--- a/jaxrs.rdf.providers/src/main/java/org/apache/clerezza/jaxrs/rdf/providers/ImmutableGraphReader.java
+++ b/jaxrs.rdf.providers/src/main/java/org/apache/clerezza/jaxrs/rdf/providers/ImmutableGraphReader.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
+import java.util.Objects;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
@@ -31,23 +32,30 @@ import javax.ws.rs.ext.Provider;
 import org.apache.clerezza.rdf.core.serializedform.Parser;
 import org.apache.clerezza.rdf.core.serializedform.SupportedFormat;
 import org.apache.clerezza.commons.rdf.ImmutableGraph;
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.Reference;
-import org.apache.felix.scr.annotations.Service;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 
-@Component
-@Service(Object.class)
-@Property(name = "javax.ws.rs", boolValue = true)
+@Component(service=Object.class, property={"javax.ws.rs=true"})
 @Provider
 @Consumes({SupportedFormat.N3, SupportedFormat.N_TRIPLE,
     SupportedFormat.RDF_XML, SupportedFormat.TURTLE,
     SupportedFormat.X_TURTLE, SupportedFormat.RDF_JSON})
 public class ImmutableGraphReader implements MessageBodyReader<ImmutableGraph> {
 
-    @Reference
     private Parser parser;
+
+    @Reference
+    public synchronized void setParser(Parser parser) {
+        this.parser = parser;
+    }
+
+    public synchronized void unsetParser(Parser parser) {
+        if (Objects.equals(this.parser, parser)) {
+            this.parser = null;
+        }
+    }
+
     @Override
     public boolean isReadable(Class<?> type, Type genericType,
             Annotation[] annotations, MediaType mediaType) {

--- a/jaxrs.rdf.providers/src/main/java/org/apache/clerezza/jaxrs/sparql/providers/ResultSetCsvMessageBodyWriter.java
+++ b/jaxrs.rdf.providers/src/main/java/org/apache/clerezza/jaxrs/sparql/providers/ResultSetCsvMessageBodyWriter.java
@@ -38,9 +38,7 @@ import org.apache.clerezza.commons.rdf.IRI;
 import org.apache.clerezza.rdf.core.sparql.ResultSet;
 import org.apache.clerezza.rdf.core.sparql.SolutionMapping;
 import org.apache.clerezza.commons.rdf.Literal;
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.Service;
+import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,9 +51,7 @@ import org.slf4j.LoggerFactory;
  * 
  * @author misl
  */
-@Component
-@Service( Object.class )
-@Property( name = "javax.ws.rs", boolValue = true )
+@Component(service=Object.class, property={"javax.ws.rs=true"})
 @Produces( { "text/csv" } )
 @Provider
 public class ResultSetCsvMessageBodyWriter implements MessageBodyWriter<ResultSet> {

--- a/jaxrs.rdf.providers/src/main/java/org/apache/clerezza/jaxrs/sparql/providers/ResultSetJsonMessageBodyWriter.java
+++ b/jaxrs.rdf.providers/src/main/java/org/apache/clerezza/jaxrs/sparql/providers/ResultSetJsonMessageBodyWriter.java
@@ -40,9 +40,7 @@ import org.apache.clerezza.rdf.core.sparql.ResultSet;
 import org.apache.clerezza.rdf.core.sparql.SolutionMapping;
 import org.apache.clerezza.rdf.core.sparql.query.Variable;
 import org.apache.clerezza.commons.rdf.Literal;
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.Service;
+import org.osgi.service.component.annotations.Component;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.slf4j.Logger;
@@ -55,9 +53,7 @@ import org.slf4j.LoggerFactory;
  * 
  * @author misl
  */
-@Component
-@Service(Object.class)
-@Property(name="javax.ws.rs", boolValue=true)
+@Component(service=Object.class, property={"javax.ws.rs=true"})
 @Produces({"application/json", "application/sparql-results+json"})
 @Provider
 @SuppressWarnings("unchecked")

--- a/jaxrs.rdf.providers/src/main/java/org/apache/clerezza/jaxrs/sparql/providers/ResultSetTsvMessageBodyWriter.java
+++ b/jaxrs.rdf.providers/src/main/java/org/apache/clerezza/jaxrs/sparql/providers/ResultSetTsvMessageBodyWriter.java
@@ -38,9 +38,7 @@ import org.apache.clerezza.commons.rdf.IRI;
 import org.apache.clerezza.rdf.core.sparql.ResultSet;
 import org.apache.clerezza.rdf.core.sparql.SolutionMapping;
 import org.apache.clerezza.commons.rdf.Literal;
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.Service;
+import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,9 +51,7 @@ import org.slf4j.LoggerFactory;
  * 
  * @author misl
  */
-@Component
-@Service( Object.class )
-@Property( name = "javax.ws.rs", boolValue = true )
+@Component(service=Object.class, property={"javax.ws.rs=true"})
 @Produces( { "text/tab-separated-values" } )
 @Provider
 public class ResultSetTsvMessageBodyWriter implements MessageBodyWriter<ResultSet> {

--- a/jaxrs.rdf.providers/src/main/java/org/apache/clerezza/jaxrs/sparql/providers/ResultSetXmlMessageBodyWriter.java
+++ b/jaxrs.rdf.providers/src/main/java/org/apache/clerezza/jaxrs/sparql/providers/ResultSetXmlMessageBodyWriter.java
@@ -47,9 +47,7 @@ import org.apache.clerezza.rdf.core.sparql.ResultSet;
 import org.apache.clerezza.rdf.core.sparql.SolutionMapping;
 import org.apache.clerezza.rdf.core.sparql.query.Variable;
 import org.apache.clerezza.commons.rdf.Literal;
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.Service;
+import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -62,9 +60,7 @@ import org.w3c.dom.Element;
  * 
  * @author mir, reto
  */
-@Component
-@Service(Object.class)
-@Property(name="javax.ws.rs", boolValue=true)
+@Component(service=Object.class, property={"javax.ws.rs=true"})
 @Produces({"application/xml", "text/xml", "application/sparql-results+xml"})
 @Provider
 public class ResultSetXmlMessageBodyWriter implements MessageBodyWriter<ResultSet> {

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -87,7 +87,7 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-scr-plugin</artifactId>
-                    <version>1.20.0</version>
+                    <version>1.25.0</version>
                     <executions>
                         <execution>
                             <id>generate-scr-scrdescriptor</id>
@@ -337,8 +337,8 @@
             </dependency>
             <dependency>
                 <groupId>javax.ws.rs</groupId>
-                <artifactId>jsr311-api</artifactId>
-                <version>1.1.1</version>
+                <artifactId>javax.ws.rs-api</artifactId>
+                <version>2.1</version>
             </dependency>
             <dependency>
                 <groupId>log4j</groupId>
@@ -379,6 +379,11 @@
                 <groupId>org.osgi</groupId>
                 <artifactId>org.osgi.core</artifactId>
                 <version>6.0.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.osgi</groupId>
+                <artifactId>org.osgi.service.component.annotations</artifactId>
+                <version>1.3.0</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>

--- a/rdf/core/pom.xml
+++ b/rdf/core/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>clerezza</artifactId>
         <groupId>org.apache.clerezza</groupId>
-        <version>7</version>
+        <version>8-SNAPSHOT</version>
         <relativePath>../../parent</relativePath>
     </parent>
     <groupId>org.apache.clerezza</groupId>

--- a/rdf/core/src/main/java/org/apache/clerezza/rdf/core/access/TcManager.java
+++ b/rdf/core/src/main/java/org/apache/clerezza/rdf/core/access/TcManager.java
@@ -47,8 +47,6 @@ import org.apache.clerezza.rdf.core.sparql.query.ConstructQuery;
 import org.apache.clerezza.rdf.core.sparql.query.DescribeQuery;
 import org.apache.clerezza.rdf.core.sparql.query.Query;
 import org.apache.clerezza.rdf.core.sparql.query.SelectQuery;
-import org.apache.felix.scr.annotations.Properties;
-import org.apache.felix.scr.annotations.Property;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.ComponentContext;
@@ -99,10 +97,10 @@ import org.osgi.service.component.annotations.ReferencePolicy;
  *
  */
 //immedia is set to true as this should register the ImmutableGraph services (even if manager service is not required)
-@Component(service = TcManager.class, immediate = true)
-@Properties({
-	@Property(name = TcManager.MGRAPH_CACHE_ENABLED, boolValue = true, description = "Enable caching mgraphs."),
-	@Property(name = TcManager.Graph_SERVICES_ENABLED, boolValue = true, description = "Register triple collections as services.") })
+@Component(service = TcManager.class, immediate = true,
+        property={
+            "graph.cache.enabled=true",
+            "Graph.services.enabled=true"})
 public class TcManager extends TcProviderMultiplexer {
 
     public final static String GENERAL_PURPOSE_TC = "general.purpose.tc";


### PR DESCRIPTION
Rather than using Felix annotations, this makes use of the official
OSGi annotations. As such, `@Reference` fields are now accessible
with `setX` and `unsetX` methods for use with OSGi declarative services.
`@Service` and `@Property` annotations have been merged with the
`@Component` declaration.

The Felix maven-scr-plugin is updated to the latest version.

The official JAX-RS dependency is also updated.

Resolves: https://issues.apache.org/jira/browse/CLEREZZA-1022